### PR TITLE
Block Manager Check Boxes aria-mixed Styling updated

### DIFF
--- a/packages/base-styles/_mixins.scss
+++ b/packages/base-styles/_mixins.scss
@@ -497,10 +497,11 @@
 				// Inherited from `forms.css`.
 				// See: https://github.com/WordPress/wordpress-develop/tree/5.1.1/src/wp-admin/css/forms.css#L122-L132
 				content: "\f460";
-				float: left;
-				display: inline-block;
-				vertical-align: middle;
-				width: 16px;
+				height: 100%;
+				display: flex;
+				justify-content: center;
+				align-items: center;
+				margin: 0;
 				/* stylelint-disable */
 				font: normal 30px/1 dashicons;
 				/* stylelint-enable */
@@ -508,8 +509,7 @@
 				-webkit-font-smoothing: antialiased;
 				-moz-osx-font-smoothing: grayscale;
 
-				@include break-medium() {
-					float: none;
+				@include break-small() {
 					font-size: 21px;
 				}
 			}


### PR DESCRIPTION
## Description
Dash was not centered in header checkbox while some not all checkbox's in group where selected. This was fixed to display dash in center of checkbox. Also dash was changing font size to early between viewports sizes.
REFER TO [ISSUE #18152](https://github.com/WordPress/gutenberg/issues/18152)

## How has this been tested?
Visually with 3 different browsers (chrome,explorer,firefox) through inspector

## Screenshots <!-- if applicable -->
BEFORE
![Screen Shot 2019-10-29 at 5 38 24 pm](https://user-images.githubusercontent.com/21496039/68252799-27aad400-0072-11ea-92d4-095e4e78cd15.png)
![Screen Shot 2019-10-29 at 5 39 19 pm](https://user-images.githubusercontent.com/21496039/68252800-27aad400-0072-11ea-89f4-c90809022b2e.png)

AFTER
![Screen Shot 2019-10-29 at 5 45 53 pm](https://user-images.githubusercontent.com/21496039/68252832-398c7700-0072-11ea-8502-299593cc708d.png)
![Screen Shot 2019-10-29 at 5 46 09 pm](https://user-images.githubusercontent.com/21496039/68252833-398c7700-0072-11ea-96c8-cd0db586c5bf.png)

## Types of changes
Styling Bug Fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
